### PR TITLE
Fix compile error on gcc 5.2.1

### DIFF
--- a/simulator/hw_motor.c
+++ b/simulator/hw_motor.c
@@ -596,7 +596,7 @@ int getPosLimitSwitch(int axis_no)
   return motor_axis[axis_no].hitPosLimitSwitch;
 }
 
-int get_bError(motor_axis_no)
+int get_bError(int motor_axis_no)
 {
 #if 0
   double HomeVelocityAbsWanted = motor_axis[motor_axis_no].HomeVelocityAbsWanted;


### PR DESCRIPTION
I was trying to install this on Ubuntu 15.10 and the compiler complained about this defaulting to `int`. Writing this explicitly removes the error.
